### PR TITLE
Added support for iOS remote videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,5 +239,5 @@ _Pvt_Extensions
 .fake/
 
 node_modules/
-platforms/
+demo/platforms/
 hooks/

--- a/platforms/ios/Info.plist
+++ b/platforms/ios/Info.plist
@@ -1,0 +1,6 @@
+<key>NSAppTransportSecurity</key>
+<dict>
+  <!--Include to allow all connections (DANGER)-->
+  <key>NSAllowsArbitraryLoads</key>
+      <true/>
+</dict>

--- a/video-source/video-source.ios.ts
+++ b/video-source/video-source.ios.ts
@@ -19,7 +19,6 @@ export class VideoSource implements definition.VideoSource {
         return this.ios != null;
     }
 
-
     public loadFromFile(path: string): boolean {
         var fileName = types.isString(path) ? path.trim() : "";
 
@@ -28,6 +27,13 @@ export class VideoSource implements definition.VideoSource {
         }
 
         let videoURL = NSURL.URLWithString(fileName);
+        let player = new AVPlayer(videoURL);
+        this.ios = player;
+        return this.ios != null;
+    }
+    
+    public loadFromUrl(url: string): boolean {
+        let videoURL = NSURL.URLWithString(url);
         let player = new AVPlayer(videoURL);
         this.ios = player;
         return this.ios != null;


### PR DESCRIPTION
Https hosted video tested successfully. Http videos need a security override by adding an entry to the Info.plist config file (included in this commit). Warning - overriding security like this might create a security hole that can possibly be exploited. This setting should be used in development only. 
See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ for more info on configuring security.