### PR TITLE
Fixes loop and finished event not working

### DIFF
--- a/videoplayer.ios.ts
+++ b/videoplayer.ios.ts
@@ -89,8 +89,9 @@ export class Video extends common.Video {
 
     private AVPlayerItemDidPlayToEndTimeNotification(notification: any) {
         var notificationString = notification.toString();
+        var source = this.src.replace("~","");
         // Check if src exists in notification, notification is structured liek so: NSConcreteNotification 0x61000024f690 {name = AVPlayerItemDidPlayToEndTimeNotification; object = <AVPlayerItem: 0x600000204190, asset = <AVURLAsset: 0x60000022b7a0, URL = https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4>>}
-        if (notificationString.includes(this.src)) {
+        if (notificationString.includes(source)) {
             this._emit(common.Video.finishedEvent);
             if (this.loop === true && this._player !== null) {
                 // Go in 5ms for more seamless looping


### PR DESCRIPTION
If a local path it's used with a ~/file.mp4 then notificationString.includes(this.src) fails as includes searches for ~ wich doesn't exist in the notification string.