### PR TITLE
adding headers to video

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ If set to true, currentTimeUpdated callback is possible.
 
 Attribute to specify an event callback to execute when the time is updated.
 
+- **headers - (Map<string, string>)** - *optional*
+
+Set headers to add when loading a video from URL.
+
+
 ## API
 
 - **play()** - Start playing the video

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     }
   },
   "scripts": {
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "build": "npm i && tsc"
   },
   "lint-staged": {
     "*.ts": ["prettier --write", "git add"]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "build": "npm i && tsc"
+    "prepare": "tsc"
   },
   "lint-staged": {
     "*.ts": ["prettier --write", "git add"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-videoplayer",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "main": "videoplayer",
   "typings": "videoplayer.d.ts",
   "description": "A NativeScript plugin that uses the native video players to play local and remote videos.",
@@ -62,6 +62,11 @@
       "name": "Ivo Georgiev",
       "email": "ivo@strem.io",
       "url": "https://github.com/Ivshti"
+    },
+    {
+      "name": "Ophir Stern",
+      "email": "souly01@gmail.com",
+      "url": "https://github.com/souly1"
     }
   ],
   "author": {

--- a/videoplayer-common.ts
+++ b/videoplayer-common.ts
@@ -36,6 +36,18 @@ function onSrcPropertyChanged(view, oldValue, newValue) {
   }
 }
 
+function onHeadersPropertyChanged(view, oldValue, newValue) {
+  const video = view;
+
+  if (oldValue !== newValue) {
+    if (video.src) {
+      let src = video.src;
+      onSrcPropertyChanged(view, null, null);
+      onSrcPropertyChanged(view, null, src);
+    }
+  }
+}
+
 export class Video extends View {
   public static finishedEvent: string = "finished";
   public static playbackReadyEvent: string = "playbackReady";
@@ -47,6 +59,7 @@ export class Video extends View {
   public android: any;
   public ios: any;
   public src: string; /// video source file
+  public headers: Map<string, string>; /// headers to use
   public observeCurrentTime: boolean; // set to true if want to observe current time.
   public autoplay: boolean = false; /// set true for the video to start playing when ready
   public controls: boolean = true; /// set true to enable the media player's playback controls
@@ -60,6 +73,12 @@ export const srcProperty = new Property<Video, any>({
   valueChanged: onSrcPropertyChanged
 });
 srcProperty.register(Video);
+
+export const headersProperty = new Property<Video, any>({
+  name: "headers",
+  valueChanged: onHeadersPropertyChanged
+});
+headersProperty.register(Video);
 
 export const videoSourceProperty = new Property<Video, any>({
   name: "videoSource"

--- a/videoplayer.android.ts
+++ b/videoplayer.android.ts
@@ -19,6 +19,7 @@ export class Video extends common.Video {
   private videoWidth;
   private videoHeight;
   private _src;
+  private _headers: java.util.Map<string, string>;
   private playState;
   private mediaState;
   private textureSurface;
@@ -37,6 +38,7 @@ export class Video extends common.Video {
     this.videoHeight = 0;
 
     this._src = null;
+    this._headers = null;
 
     this.playState = STATE_IDLE;
     this.mediaState = SURFACE_WAITING;
@@ -50,6 +52,10 @@ export class Video extends common.Video {
 
   get android(): any {
     return this.nativeView;
+  }
+
+  [common.headersProperty.setNative](value) {
+    this._setHeader(value ? value : null);
   }
 
   [common.videoSourceProperty.setNative](value) {
@@ -366,9 +372,18 @@ export class Video extends common.Video {
 
       this._setupMediaPlayerListeners();
 
-      this.mediaPlayer.setDataSource(
-        /* utils.ad.getApplicationContext(),*/ this._src
-      );
+      if (!this._headers || this._headers.size() === 0) {
+        this.mediaPlayer.setDataSource(
+          /* utils.ad.getApplicationContext(),*/ this._src
+        );
+      } else {
+        let videoUri = android.net.Uri.parse(this._src);
+        this.mediaPlayer.setDataSource(
+          utils.ad.getApplicationContext(),
+          videoUri,
+          this._headers
+        );
+      }
       this.mediaPlayer.setSurface(this.textureSurface);
       this.mediaPlayer.setAudioStreamType(
         android.media.AudioManager.STREAM_MUSIC
@@ -385,6 +400,18 @@ export class Video extends common.Video {
   public _setNativeVideo(nativeVideo: any): void {
     this._src = nativeVideo;
     this._openVideo();
+  }
+
+  public _setHeader(headers: Map<string, string>): void {
+    if (headers && headers.size > 0) {
+      this._headers = new java.util.HashMap();
+      headers.forEach((value: string, key: string) => {
+        this._headers.put(key, value);
+      });
+    }
+    if (this._src) {
+      this._openVideo();
+    }
   }
 
   public setNativeSource(nativePlayerSrc: string): void {

--- a/videoplayer.android.ts
+++ b/videoplayer.android.ts
@@ -345,7 +345,9 @@ export class Video extends common.Video {
     if (
       this._src === null ||
       this.textureSurface === null ||
-      (typeof this._src === "string" && this._src.length === 0)
+      (this._src !== null &&
+        typeof this._src === "string" &&
+        this._src.length === 0)
     ) {
       // we have to protect In case something else calls this before we are ready
       // the Surface event will then call this when we are ready...

--- a/videoplayer.android.ts
+++ b/videoplayer.android.ts
@@ -342,7 +342,11 @@ export class Video extends common.Video {
   }
 
   private _openVideo(): void {
-    if (this._src === null || this.textureSurface === null) {
+    if (
+      this._src === null ||
+      this.textureSurface === null ||
+      (typeof this._src === "string" && this._src.length === 0)
+    ) {
       // we have to protect In case something else calls this before we are ready
       // the Surface event will then call this when we are ready...
       return;

--- a/videoplayer.d.ts
+++ b/videoplayer.d.ts
@@ -3,6 +3,7 @@ export declare class Video extends View {
   android: any;
   ios: any;
   src: string; /// video source file
+  headers: Map<string, string>; /// headers to use
   loop: boolean; /// whether the video loops the playback after extends
   autoplay: boolean; /// set true for the video to start playing when ready
   controls: boolean; /// set true to enable the media player's playback controls


### PR DESCRIPTION
* Added ability to add headers to video source loaded from URL - This is useful, for example, when one wants to add an authorization header to video requests.

Solution based on:
Android: https://developer.android.com/reference/android/media/MediaPlayer.html#setDataSource(android.content.Context, android.net.Uri, java.util.Map<java.lang.String, java.lang.String>)
iOS: https://stackoverflow.com/questions/15456130/send-headers-with-avplayer-request-in-ios/23713028#23713028